### PR TITLE
newinfo数据库建立与数据传输

### DIFF
--- a/cloudFunctions/publicsche/index.js
+++ b/cloudFunctions/publicsche/index.js
@@ -26,14 +26,17 @@ exports.main = async (event, context) => {
     //     }
     //   });
     // }
+    await newinfo.map(x=>{
+      delete (x["_id"])
+    })
+    console.log(newinfo)
     await newinfoCollection.add({
-      data: {
-        newinfo
-      }
+      data:newinfo
     });
     return {
       code: 200,
-      schedule: schedule
+      schedule: schedule,
+      newinfo:newinfo
     }
   } catch (e) {
     return {

--- a/src/pages/joinSchedule/joinSchedule.tsx
+++ b/src/pages/joinSchedule/joinSchedule.tsx
@@ -18,6 +18,7 @@ import {
 } from "taro-ui";
 import Banci from "../../classes/banci";
 import info from "../../classes/info";
+import newinfo from "../../classes/newinfo"
 import Schedule from "../../classes/schedule";
 import User from "../../classes/user";
 import UserBadge from "../../components/UserBadge";
@@ -25,12 +26,14 @@ import { updateBanci } from "../../redux/actions/banci";
 import { deleteInfo, updateInfo } from "../../redux/actions/info";
 import { updateSchedule } from "../../redux/actions/schedule";
 import { setUserData } from "../../redux/actions/user";
+import { updatenewInfo } from "../../redux/actions/newinfo";
 import store from "../../redux/store";
 import { AppState } from "../../redux/types";
-import { getPerscheResult, loginResult, updatescheResult,arrangescheResult } from "../../types";
+import { getPerscheResult, loginResult, updatescheResult,arrangescheResult,publicscheResult } from "../../types";
 import checkIfInvolved from "../../utils/checkIfInvolved";
 import getDateFromString from "../../utils/getDateFromString";
 import getDateString from "../../utils/getDateString";
+
 
 /** 定义这个页面的 Props 和 States */
 type Props = {
@@ -38,11 +41,13 @@ type Props = {
     schedules: Array<Schedule>;
     bancis: Array<Banci>;
     infos: Array<info>;
+    newinfos: Array<newinfo>;
     setUserData: (user: User) => void;
     updateInfo: (info: info) => void;
     deleteInfo: (id: string) => void;
     updateBanci: (banci: Banci) => void;
     updateSchedule: (Schedule: Schedule) => void;
+    updatenewInfo: (newinfo:newinfo) => void;
 };
 
 type States = {
@@ -76,7 +81,8 @@ function mapStateToProps(state: AppState) {
         user: state.user,
         schedules: state.schedules,
         bancis: state.bancis,
-        infos: state.infos
+        infos: state.infos,
+        newinfos:state.newinfos,
     };
 }
 
@@ -96,6 +102,9 @@ function mapDispatchToProps(dispatch: typeof store.dispatch) {
         },
         updateBanci: (banci: Banci) => {
             dispatch(updateBanci(banci));
+        },
+        updatenewInfo: (newinfo: newinfo)=>{
+            dispatch(updatenewInfo(newinfo));
         }
     };
 }
@@ -181,8 +190,18 @@ class JoinSchedule extends Component<Props, States> {
         name: "publicsche",
         data: {
             schedule: schedule,
-            info:newinfo
+            newinfo:newinfo
         }
+      })
+      .then(res =>{
+        var resdata = (res as unknown) as publicscheResult;
+        if (resdata.result.code === 200) {
+          resdata.result.newinfo.map(newinfo => {
+            this.props.updatenewInfo(newinfo);
+          });
+        }
+        // console.log(this.props)
+        // console.log(this.props.newinfos)
       })
       Taro.showToast({ title: "发布成功", icon: "success", duration: 2000 });
       Taro.redirectTo({

--- a/src/pages/scheduleDetail/scheduleDetail.tsx
+++ b/src/pages/scheduleDetail/scheduleDetail.tsx
@@ -6,9 +6,11 @@ import Banci from "../../classes/banci";
 import info from "../../classes/info";
 import Schedule from "../../classes/schedule";
 import User from "../../classes/user";
+import newinfo from "../../classes/newinfo"
 import { updateBanci } from "../../redux/actions/banci";
 import { updateInfo } from "../../redux/actions/info";
 import { updateSchedule } from "../../redux/actions/schedule";
+import { updatenewInfo } from "../../redux/actions/newinfo";
 import store from "../../redux/store";
 import { AppState } from "../../redux/types";
 import { updatescheResult } from "../../types";
@@ -21,15 +23,19 @@ type Props = {
     schedules: Array<Schedule>;
     bancis: Array<Banci>;
     infos: Array<info>;
+    newinfos:Array<newinfo>;
     updateSchedule: (Schedule: Schedule) => void;
     updateBanci: (banci: Banci) => void;
     updateInfo: (info: info) => void;
+    updatenewInfo:(newinfo: newinfo) =>void;
 };
 
 type States = {
     schedule: Schedule;
     bancis: Array<Banci>;
     infos: Array<info>;
+    newinfos:Array<newinfo>;
+
     openbanci: boolean;
 
     // 当前编辑的班表信息
@@ -49,7 +55,8 @@ function mapStateToProps(state: AppState) {
         user: state.user,
         schedules: state.schedules,
         bancis: state.bancis,
-        infos: state.infos
+        infos: state.infos,
+        newinfos: state.newinfos
     };
 }
 
@@ -63,7 +70,10 @@ function mapDispatchToProps(dispatch: typeof store.dispatch) {
         },
         updateInfo: (info: info) => {
             dispatch(updateInfo(info));
-        }
+        },
+        updatenewInfo: (newinfo: newinfo)=>{
+          dispatch(updatenewInfo(newinfo));
+      }
     };
 }
 
@@ -74,6 +84,7 @@ class ScheduleDetail extends Component<Props, States> {
             schedule: new Schedule(),
             bancis: new Array<Banci>(),
             infos: new Array<info>(),
+            newinfos:new Array<newinfo>(),
             openbanci: false,
             openmodal: undefined,
             editing: undefined,
@@ -140,6 +151,7 @@ class ScheduleDetail extends Component<Props, States> {
     componentDidMount() {
         var scheID = this.$router.params._id;
         var sc = this.props.schedules.find(sc => sc._id === scheID);
+        console.log(this.props)
         /** 检查当前查看的班表有没有被下载了，没有的话代表用户试图访问和他无关的班表 */
         if (sc === undefined) {
             Taro.showToast({ title: "班表不存在", icon: "none", duration: 2000 });
@@ -148,6 +160,8 @@ class ScheduleDetail extends Component<Props, States> {
             });
         } else {
             this.setState({ schedule: sc });
+            var newinfo = this.props.newinfos.filter(newinfo => newinfo.scheid === scheID)
+            this.setState({ newinfos:newinfo })
             let infor = new Array<info>();
             let ban = this.props.bancis.filter(banci => {
                 if (sc !== undefined && banci.scheid === sc._id) {
@@ -188,7 +202,9 @@ class ScheduleDetail extends Component<Props, States> {
     }
     render() {
         const schedule = this.state.schedule;
-        const { infos } = this.state;
+        // const { infos } = this.state;
+        const { newinfos } = this.state;
+
 
         if (schedule === undefined) return <View>发生错误</View>;
 
@@ -236,11 +252,11 @@ class ScheduleDetail extends Component<Props, States> {
                                                 </View>
                                                 {/* 循环班次成员获取tag */}
                                                 <View>
-                                                    {infos.filter(info => info.classid === item._id).length === 0 ? (
+                                                    {newinfos.filter(info => info.classid === item._id).length === 0 ? (
                                                         <Text>没有成员</Text>
                                                     ) : (
                                                         <View>
-                                                            {infos.map(x => {
+                                                            {newinfos.map(x => {
                                                                 if (x.classid === item._id)
                                                                     return (
                                                                         <AtBadge key={item._id}>

--- a/src/redux/actions/newinfo.ts
+++ b/src/redux/actions/newinfo.ts
@@ -1,0 +1,26 @@
+import newinfo from "src/classes/newinfo";
+import { UPDATE_NEWINFO } from "../constants/newinfo";
+
+interface updatenewInfo {
+    type: typeof UPDATE_NEWINFO;
+    data: newinfo;
+}
+
+// interface deleteInfo {
+//     type: typeof DELETE_INFO;
+//     data: string;
+// }
+
+/** 对 Redux 中 info 数据的 Actions */
+export type NewinfoActions = updatenewInfo ;
+
+/** 将新的 newInfo 存入 Redux （或是覆写原有的 newInfo) */
+export function updatenewInfo(data: newinfo): updatenewInfo {
+  console.log(data)
+    return { type: UPDATE_NEWINFO, data: data };
+}
+
+/** 从 Redux 删除 Info */
+// export function deleteInfo(data: string): deleteInfo {
+//     return { type: DELETE_INFO, data: data };
+// }

--- a/src/redux/constants/newinfo.ts
+++ b/src/redux/constants/newinfo.ts
@@ -1,0 +1,1 @@
+export const UPDATE_NEWINFO = "UPDATE_NEWINFO";

--- a/src/redux/reducers/index.ts
+++ b/src/redux/reducers/index.ts
@@ -3,10 +3,12 @@ import user from "./user";
 import schedules from "./schedules";
 import bancis from "./bancis";
 import infos from "./infos";
+import newinfos from "./newinfo";
 
 export default combineReducers({
     user,
     schedules,
     bancis,
-    infos
+    infos,
+    newinfos
 });

--- a/src/redux/reducers/newinfo.ts
+++ b/src/redux/reducers/newinfo.ts
@@ -1,0 +1,16 @@
+import newinfo from "../../classes/newinfo";
+import { NewinfoActions } from "../actions/newinfo";
+import { UPDATE_NEWINFO } from "../constants/newinfo";
+
+/** 已经从数据库下载的 info 数据 */
+export default function newinfos(state: Array<newinfo> = [], action: NewinfoActions) {
+
+    switch (action.type) {
+        case UPDATE_NEWINFO:
+            return [...state.filter(newinfo => newinfo._id !== action.data._id), action.data];
+        // case DELETE_INFO:
+        //     return [...state.filter(info => info._id !== action.data)];
+        default:
+            return state;
+    }
+}

--- a/src/redux/types.ts
+++ b/src/redux/types.ts
@@ -3,10 +3,12 @@ import User from "src/classes/user";
 import Schedule from "src/classes/schedule";
 import info from "src/classes/info";
 import Banci from "src/classes/banci";
+import newinfo from "src/classes/newinfo";
 
 export type AppState = CombinedState<{
     user: User;
     schedules: Array<Schedule>;
     infos: Array<info>;
     bancis: Array<Banci>;
+    newinfos:Array<newinfo>;
 }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import Banci from "src/classes/banci";
 import info from "./classes/info";
 import Schedule from "./classes/schedule";
 import User from "./classes/user";
+import newinfo from "./classes/newinfo"
 
 /** 云函数 "Login" 的返回格式 */
 export interface loginResult {
@@ -83,5 +84,15 @@ export interface deleteinfoResult{
   requestID: string;
   result: {
     code: number;
+  }
+}
+
+export interface publicscheResult{
+  errMsg: string;
+  requestID: string;
+  result:{
+    code: number;
+    schedule:Schedule;
+    newinfo: Array<newinfo>;
   }
 }


### PR DESCRIPTION
建了newinfo的表
将detail页面与join页面的数据显示分离（detail根据newinfo里的数据显示）
BUG：主页面在detail返回后不刷新
tag每次重新进入join界面都会清空 且状态不保存 导致一个user可以有多个tag
显示未成功人员与class的显示内容还没有确定